### PR TITLE
Fix installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Simple web interface for the Deepgram Voice AI Agent API showing a simple menu o
 ## Installation
 
 ```
-npm -g http-server
+npm install -g http-server
 ```
 
 ## Running


### PR DESCRIPTION
This PR fixes the installation command in the README.

(was `npm -g http-server`, changed to `npm install -g http-server`)